### PR TITLE
Merge branch 'python-setup' of iob-soc into python-setup

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_tester_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_tester_fpga_wrapper.v
@@ -152,7 +152,7 @@ module iob_soc_tester_fpga_wrapper
    wire          rst_int = ~resetn | ~locked | ~init_done;
 //   wire          rst_int = ~resetn | ~locked;
    
-   iob_reset_sync rst_sync (clk, rst_int, 1'b1, rst);
+   iob_reset_sync rst_sync (clk, rst_int, rst);
 
    alt_ddr3 ddr3_ctrl 
      (
@@ -228,7 +228,7 @@ module iob_soc_tester_fpga_wrapper
       );
 
 `else 
-   iob_reset_sync rst_sync (clk, (~resetn), 1'b1, rst);   
+   iob_reset_sync rst_sync (clk, (~resetn), rst);   
 `endif
 
 `ifdef IOB_SOC_TESTER_USE_EXTMEM

--- a/hardware/fpga/vivado/AES-KU040-DB-G/clock_wizard.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/clock_wizard.v
@@ -65,30 +65,26 @@
 `timescale 1ps/1ps
 
 module clock_wizard #(
-		      parameter CLK_OUTPUT_PER = 10,
-		      parameter MCLK_OUTPUT_PER = 7,
+		      parameter OUTPUT_PER = 10,
 		      parameter INPUT_PER = 4
 		      ) 
 
   (// Clock in ports
    // Clock out ports
-   input  clk_in1_p,
-   input  clk_in1_n,
    output clk_out1,
-   output clk_out2
+   input  clk_in1_p,
+   input  clk_in1_n
    );
    // Input buffering
    //------------------------------------
-
    wire   clk_in1_clock_wizard;
    wire   clk_in2_clock_wizard;
-
    IBUFDS clkin1_ibufds
-     (
+     (.O  (clk_in1_clock_wizard),
       .I  (clk_in1_p),
-      .IB (clk_in1_n),
-      .O  (clk_in1_clock_wizard)
-      );
+      .IB (clk_in1_n));
+
+
 
 
    // Clocking PRIMITIVE
@@ -119,6 +115,10 @@ module clock_wizard #(
    wire        clkinstopped_unused;
 
    
+
+   // Auto Instantiation//
+
+   
    PLLE3_ADV
      #(
        .COMPENSATION         ("AUTO"),
@@ -126,12 +126,9 @@ module clock_wizard #(
        .DIVCLK_DIVIDE        (1),
        .CLKFBOUT_MULT        (4),
        .CLKFBOUT_PHASE       (0.000),
-       .CLKOUT0_DIVIDE       (4*CLK_OUTPUT_PER/INPUT_PER),
+       .CLKOUT0_DIVIDE       (4*OUTPUT_PER/INPUT_PER),
        .CLKOUT0_PHASE        (0.000),
        .CLKOUT0_DUTY_CYCLE   (0.500),
-       .CLKOUT1_DIVIDE       (4*MCLK_OUTPUT_PER/INPUT_PER),
-       .CLKOUT1_PHASE        (0.000),
-       .CLKOUT1_DUTY_CYCLE   (0.500),
        .CLKIN_PERIOD         (INPUT_PER))
    plle3_adv_inst
      // Output clocks
@@ -139,7 +136,7 @@ module clock_wizard #(
       .CLKFBOUT            (clkfbout_clock_wizard),
       .CLKOUT0             (clk_out1_clock_wizard),
       .CLKOUT0B            (clkout0b_unused),
-      .CLKOUT1             (clkout2_clock_wizard),
+      .CLKOUT1             (clkout1_unused),
       .CLKOUT1B            (clkout1b_unused),
       // Input clock control
       .CLKFBIN             (clkfbout_clock_wizard),
@@ -160,18 +157,22 @@ module clock_wizard #(
       .RST                 (1'b0));
 
 
-   // Output clock buffers
+
+   // Clock Monitor clock assigning
+   //--------------------------------------
+   // Output buffering
+   //-----------------------------------
+
+
+
+
+
+
    BUFG clkout1_buf
-     (
-      .I   (clk_out1_clock_wizard),
-      .O   (clk_out1)
-      );
+     (.O   (clk_out1),
+      .I   (clk_out1_clock_wizard));
 
 
-   BUFG clkout2_buf
-     (
-      .I   (clk_out2_clock_wizard),
-      .O   (clk_out2)
-      );
+
 
 endmodule

--- a/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_tester_fpga_wrapper.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_tester_fpga_wrapper.v
@@ -435,7 +435,7 @@ module iob_soc_tester_fpga_wrapper
     iob_reset_sync start_sync (
         .clk_i(clk),
         .arst_i(reset),
-        .rst_o(start)
+        .arst_o(start)
         );
 
     //create reset pulse as reset is never activated manually

--- a/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_tester_fpga_wrapper.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_tester_fpga_wrapper.v
@@ -435,7 +435,6 @@ module iob_soc_tester_fpga_wrapper
     iob_reset_sync start_sync (
         .clk_i(clk),
         .arst_i(reset),
-        .cke_i(1'b1),
         .rst_o(start)
         );
 


### PR DESCRIPTION
- Merge branch 'python-setup' of iob-soc into python-setup
- Restore `clock_wizard` back to the same state as it is in the iob-soc system. The `clock_wizard` with two outputs was moved to the repository of the specific project that needs it.